### PR TITLE
18 refine gha to not check for devel branch instead make all branches get the devel label

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -15,11 +15,6 @@ env:
 jobs:
   docker:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch: 
-          - master
-          - devel
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,7 +9,6 @@ env:
   REGISTRY: ghcr.io
   REPO: pipeittodevnull
   IMAGE: nginx-certbot
-  BRANCH: ${{ github.head_ref || github.ref_name }} 
 
 jobs:
   docker:
@@ -35,7 +34,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
+        
+        # This step uses a verbose sha variable to remove the "sha-" default prefix. This is required so the image has a short sha prefix that is easier to obtain in the SBOM step. The SBOM step was previously using branch name to pull, but we are renaming our branches to all be "devel" so we cannot use the branch variable in the SBOM pull step 
+        # We are doing a negative match on "master" to label any non-master branch as devel. There is an open issue for negative matching is_default_branch which would be better https://github.com/docker/metadata-action/issues/247
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
@@ -44,7 +45,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}
           flavor: latest=auto
           tags: |
-            type=sha,enable=true,priority=100,prefix=,suffix=,format=short
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=long
             type=raw,value=devel,enable=${{ github.ref != format('refs/heads/{0}', 'master') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
@@ -67,7 +68,7 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ env.BRANCH }}
+          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ github.sha }}
           artifact-name: ${{ env.IMAGE }}-${{ env.BRANCH }}.spdx
           format: spdx-json
           upload-artifact: true

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,13 +4,12 @@ name: Publish Docker image multi-arch
 on:
   push:
   workflow_dispatch:
-  schedule:
-    - cron: "0 13 * * *"
 
 env:
   REGISTRY: ghcr.io
   REPO: pipeittodevnull
   IMAGE: nginx-certbot
+  BRANCH: ${{ github.head_ref || github.ref_name }} 
 
 jobs:
   docker:
@@ -23,8 +22,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ matrix.branch }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -70,8 +67,8 @@ jobs:
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:
-          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ matrix.branch }}
-          artifact-name: ${{ env.IMAGE }}-${{ matrix.branch }}.spdx
+          image: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}:${{ env.BRANCH }}
+          artifact-name: ${{ env.IMAGE }}-${{ env.BRANCH }}.spdx
           format: spdx-json
           upload-artifact: true
           upload-artifact-retention: 7

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,6 +4,8 @@ name: Publish Docker image multi-arch
 on:
   push:
   workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *"
 
 env:
   REGISTRY: ghcr.io
@@ -65,6 +67,7 @@ jobs:
           subject-name: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE}}
           subject-digest: ${{ steps.push.outputs.digest }}
 
+        # This steps pulls the container, you need a valid already pushed image that will resolve to the container you just pushed 2 seconds ago. We are using the SHA here because I believe that to be the most truthful method
       - name: Generate SBOM
         uses: anchore/sbom-action@v0
         with:

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -3,9 +3,6 @@ name: Publish Docker image multi-arch
 
 on:
   push:
-    branches:
-      - master
-      - devel
   workflow_dispatch:
   schedule:
     - cron: "0 13 * * *"
@@ -55,7 +52,8 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}
           flavor: latest=auto
           tags: |
-            type=raw,value={{branch}}
+            type=sha
+            type=raw,value=devel,enable=${{ github.ref != format('refs/heads/{0}', 'master') }}
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -44,7 +44,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.REPO }}/${{ env.IMAGE }}
           flavor: latest=auto
           tags: |
-            type=sha
+            type=sha,enable=true,priority=100,prefix=,suffix=,format=short
             type=raw,value=devel,enable=${{ github.ref != format('refs/heads/{0}', 'master') }}
             type=raw,value=latest,enable={{is_default_branch}}
 


### PR DESCRIPTION
This should close #18 and will hopefully not break scheduled builds