### PR TITLE
Fix dns resolution when a backend container restarts

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -110,3 +110,5 @@ podman run -d \
 ```bash
 podman build -t nginx-certbot:latest .
 ```
+## Hostname resolution
+In order to update the IP of a backend container once it has been restarted this container must specify a DNS server. For Podman this defaults to `10.88.0.1`, if you alter your container networking this will have to be amended in `src/skel.conf` and the container will have to be built yourself.

--- a/conf.d/site.conf.sample
+++ b/conf.d/site.conf.sample
@@ -2,7 +2,9 @@ server {
   listen 80;
   server_name contoso.com;
   resolver @@resolver@@ valid=30s ipv6=off;
+
   location / {
-      proxy_pass http://$webserver_container_name;
+      set $backend http://$webserver_container_name;
+      proxy_pass $backend;
   }
 }

--- a/conf.d/site.conf.sample
+++ b/conf.d/site.conf.sample
@@ -1,12 +1,8 @@
-resolver 10.88.0.1 valid=30s;
-upstream backend-$webserver_container_name {
-  server $webserver_container_name;
-}
-
 server {
   listen 80;
   server_name contoso.com;
+  resolver @@resolver@@ valid=30s ipv6=off;
   location / {
-      proxy_pass http://backend-$webserver_container_name;
+      proxy_pass http://$webserver_container_name;
   }
 }

--- a/conf.d/site.conf.sample
+++ b/conf.d/site.conf.sample
@@ -1,7 +1,12 @@
+resolver 10.88.0.1 valid=30s;
+upstream backend-$webserver_container_name {
+  server $webserver_container_name;
+}
+
 server {
   listen 80;
   server_name contoso.com;
   location / {
-      proxy_pass http://webserver_container_name/;
+      proxy_pass http://backend-$webserver_container_name;
   }
 }

--- a/src/nginx_setup.py
+++ b/src/nginx_setup.py
@@ -2,6 +2,7 @@ import os
 import json
 import re
 import logging
+import subprocess
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 
@@ -19,6 +20,19 @@ else:
 
 email = os.getenv('EMAIL')
 prod = os.getenv('PRODUCTION')
+
+# get resolver
+resolver = None
+try:
+    out = subprocess.check_output(['ip', 'route'], stderr=subprocess.DEVNULL).decode()
+    m = re.search(r'^default via (\d+\.\d+\.\d+\.\d+)', out, re.MULTILINE)
+    if m:
+        resolver = m.group(1)
+except Exception:
+    resolver = os.getenv('10.88.0.1')
+    logging.info("ip route unavailable, obtaining resolver failed. Container IPs most likely won't update after restarting")
+
+logging.info("Using resolver: " + resolver)
 
 # copy in any manual conf files the user made
 os.system("cp -rf /etc/nginx/conf.avail/*.conf /etc/nginx/http.d/ &> /dev/null")
@@ -44,7 +58,11 @@ for host in hosts_json:
             with open('/root/skel.conf') as conf_file:
                 conf_contents = conf_file.read()
 
-            conf_complete = re.sub(r"@@(\w+?)@@", lambda match: host[match.group(1)], conf_contents)
+            conf_complete = re.sub(
+                r"@@(\w+?)@@",
+                lambda match: host.get('resolver', resolver) if match.group(1) == 'resolver' else host[match.group(1)],
+                conf_contents
+            )
 
             logging.info("Writing /etc/nginx/http.d/" + host['hostname'] + ".conf")
 

--- a/src/nginx_setup.py
+++ b/src/nginx_setup.py
@@ -60,7 +60,7 @@ for host in hosts_json:
 
             conf_complete = re.sub(
                 r"@@(\w+?)@@",
-                lambda match: host.get('resolver', resolver) if match.group(1) == 'resolver' else host[match.group(1)],
+                lambda match, host=host: str(host.get('resolver', resolver)) if match.group(1) == 'resolver' else str(host.get(match.group(1), '')),
                 conf_contents
             )
 

--- a/src/skel.conf
+++ b/src/skel.conf
@@ -2,7 +2,9 @@ server {
   listen 80;
   server_name @@hostname@@;
   resolver @@resolver@@ valid=30s ipv6=off;
+
   location / {
-      proxy_pass @@proxy_pass@@;
+      set $backend @@proxy_pass@@;
+      proxy_pass $backend;
   }
 }

--- a/src/skel.conf
+++ b/src/skel.conf
@@ -1,12 +1,8 @@
-resolver 10.88.0.1 valid=30s;
-upstream backend-@@hostname@@ {
-  server @@proxy_pass@@;
-}
-
 server {
   listen 80;
   server_name @@hostname@@;
+  resolver @@resolver@@ valid=30s ipv6=off;
   location / {
-      proxy_pass backend-@@hostname@@;
+      proxy_pass @@proxy_pass@@;
   }
 }

--- a/src/skel.conf
+++ b/src/skel.conf
@@ -1,7 +1,12 @@
+resolver 10.88.0.1 valid=30s;
+upstream backend-@@hostname@@ {
+  server @@proxy_pass@@;
+}
+
 server {
   listen 80;
   server_name @@hostname@@;
   location / {
-      proxy_pass @@proxy_pass@@;
+      proxy_pass backend-@@hostname@@;
   }
 }


### PR DESCRIPTION
Nginx caches the resolution of the backend when it starts, you must specify a resolver to update the cached IP without having to restart